### PR TITLE
Fix: Add missing CDN dependencies and correct stylesheet path

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,9 @@
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>Polar Clock Pro</title>
-        <link rel="stylesheet" href="style.css">
+        <script src="https://cdn.tailwindcss.com"></script>
+        <script src="https://unpkg.com/@phosphor-icons/web"></script>
+        <link rel="stylesheet" href="src/css/style.css">
     </head>
     <body>
         <div id="loading-overlay" style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; background-color: #121212; display: flex; justify-content: center; align-items: center; z-index: 9999; transition: opacity 0.5s;">


### PR DESCRIPTION
The application was failing to render because of two issues in `index.html`:
1. The stylesheet `style.css` was referenced at the root, but is located in `src/css/`.
2. The CDN script tags for Tailwind CSS and Phosphor Icons, which are required for the new UI components, were missing.

This commit corrects the stylesheet path and adds the necessary CDN links to the `<head>`, which resolves the rendering failure.